### PR TITLE
remove ListOptions from AccountService.List signature

### DIFF
--- a/internal/client/account.go
+++ b/internal/client/account.go
@@ -10,7 +10,7 @@ import (
 type AccountService interface {
 	// Returns a list of accounts that the user has access to.
 	// See: https://docs.us.lifeomic.com/api/#list-all-accounts
-	List(context.Context, ListOptions) ([]Account, error)
+	List(context.Context) ([]Account, error)
 }
 
 // AccountType represents the type of an Account.
@@ -41,7 +41,7 @@ type accountListResponse struct {
 	Accounts []Account `json:"accounts"`
 }
 
-func (s *accountService) List(ctx context.Context, options ListOptions) ([]Account, error) {
+func (s *accountService) List(ctx context.Context) ([]Account, error) {
 	req := s.Request(ctx).SetResult(&accountListResponse{})
 	req.Header.Del(accountHeader)
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1,0 +1,1 @@
+package provider

--- a/main.go
+++ b/main.go
@@ -14,9 +14,7 @@ func main() {
 	})
 
 	// List accounts
-	accountList, err := cli.Accounts().List(ctx, client.ListOptions{
-		PageSize: 1,
-	})
+	accountList, err := cli.Accounts().List(ctx)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
As the `GET /v1/accounts` endpoint does not support paging, the function
should not take ListOptions as an argument. I missed this before merging
the client code into master.