### PR TITLE
PRVT-134: add notIncludes, suffixOf, and prefixOf comparison types

### DIFF
--- a/internal/client/policies.go
+++ b/internal/client/policies.go
@@ -236,16 +236,19 @@ type ComparisonType string
 
 // supported comparison constants
 const (
-	ComparisonEquals     ComparisonType = "equals"
-	ComparisonNotEquals  ComparisonType = "notEquals"
-	ComparisonIncludes   ComparisonType = "includes"
-	ComparisonIn         ComparisonType = "in"
-	ComparisonNotIn      ComparisonType = "notIn"
-	ComparisonExists     ComparisonType = "exists"
-	ComparisonSuperset   ComparisonType = "superset"
-	ComparisonSubset     ComparisonType = "subset"
-	ComparisonStartsWith ComparisonType = "startsWith"
-	ComparisonEndsWith   ComparisonType = "endsWith"
+	ComparisonEquals       ComparisonType = "equals"
+	ComparisonNotEquals    ComparisonType = "notEquals"
+	ComparisonIncludes     ComparisonType = "includes"
+	ComparisonNotIncludes  ComparisonType = "notIncludes"
+	ComparisonIn           ComparisonType = "in"
+	ComparisonNotIn        ComparisonType = "notIn"
+	ComparisonExists       ComparisonType = "exists"
+	ComparisonSuperset     ComparisonType = "superset"
+	ComparisonSubset       ComparisonType = "subset"
+	ComparisonStartsWith   ComparisonType = "startsWith"
+	ComparisonPrefixOf     ComparisonType = "prefixOf"
+	ComparisonEndsWith     ComparisonType = "endsWith"
+	ComparisonSuffixOf     ComparisonType = "suffixOf"
 )
 
 type policyService struct {


### PR DESCRIPTION
## Motivation
Support for these comparison types were recently added to the core ABAC utility: https://github.com/lifeomic/abac/pull/65