### PR TITLE
fix: change release gpg secrets to match repo-standard

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,12 @@
 # This GitHub action can publish assets for release when a tag is created.
 # Currently its setup to run on any tag that matches the pattern "v*" (ie. v0.1.0).
 #
-# This uses an action (hashicorp/ghaction-import-gpg) that assumes you set your 
+# This uses an action (hashicorp/ghaction-import-gpg) that assumes you set your
 # private key in the `GPG_PRIVATE_KEY` secret and passphrase in the `PASSPHRASE`
 # secret. If you would rather own your own GPG handling, please fork this action
 # or use an alternative one for key handling.
 #
-# You will need to pass the `--batch` flag to `gpg` in your signing step 
+# You will need to pass the `--batch` flag to `gpg` in your signing step
 # in `goreleaser` to indicate this is being used in a non-interactive mode.
 #
 name: release
@@ -19,32 +19,26 @@ jobs:
     runs-on: ubuntu-latest
     environment: terraform-registry
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v2.4.0
-      -
-        name: Unshallow
+      - name: Unshallow
         run: git fetch --prune --unshallow
       - name: Install semantic-release Dependency
         run: npm install -g semantic-release conventional-changelog-conventionalcommits
-      -
-        name: Tag Release
+      - name: Tag Release
         run: semantic-release
-      -
-        name: Set up Go
+      - name: Set up Go
         uses: actions/setup-go@v2
         with:
           go-version: 1.17
-      -
-        name: Import GPG key
+      - name: Import GPG key
         id: import_gpg
         uses: hashicorp/ghaction-import-gpg@v2.1.0
         env:
           # These secrets will need to be configured for the repository:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          PASSPHRASE: ${{ secrets.GPG_PRIVATE_KEY_PASSPHRASE }}
-      -
-        name: Run GoReleaser
+          GPG_PRIVATE_KEY: ${{ secrets.LIFEOMIC_GPG_PRIVATE_KEY }}
+          PASSPHRASE: ${{ secrets.LIFEOMIC_GPG_PRIVATE_KEY_PASSPHRASE }}
+      - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2.8.0
         with:
           version: latest


### PR DESCRIPTION
Same as: https://github.com/lifeomic/terraform-provider-marketplace/pull/13/files