### PR TITLE
fix: NO-JIRA enable probot

### DIFF
--- a/.github/lifeomic-probot.yml
+++ b/.github/lifeomic-probot.yml
@@ -1,0 +1,1 @@
+enforceSemanticCommits: true


### PR DESCRIPTION
Enabling probot (and triggering a release because the `release` job was manually disabled)