### PR TITLE
fix: use crazy-max/ghaction-import-gpg instead of hashicorp

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,10 +33,10 @@ jobs:
         go-version: 1.17
     - name: Import GPG key
       id: import_gpg
-      uses: hashicorp/ghaction-import-gpg@v2.1.0
+      uses: crazy-max/ghaction-import-gpg@v5.0.0
       env:
-        GPG_PRIVATE_KEY: ${{ secrets.LIFEOMIC_GPG_PRIVATE_KEY }}
-        PASSPHRASE: ${{ secrets.LIFEOMIC_GPG_PRIVATE_KEY_PASSPHRASE }}
+        gpg_private_key: ${{ secrets.LIFEOMIC_GPG_PRIVATE_KEY }}
+        passphrase: ${{ secrets.LIFEOMIC_GPG_PRIVATE_KEY_PASSPHRASE }}
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2.8.0
       with:


### PR DESCRIPTION
Now that GitHub action runners run gpg-agent by default, this action is broken. Also, this action is apparently in public archive in favor of the original action `crazy-max/ghaction-import-gpg`.  See: https://github.com/hashicorp/ghaction-import-gpg/issues/11#issuecomment-1185107410